### PR TITLE
Add formatting label input

### DIFF
--- a/src/bootstrap-weekpicker.js
+++ b/src/bootstrap-weekpicker.js
@@ -1,7 +1,15 @@
 (function($) {
 
-    $.fn.weekpicker = function() {
+    $.fn.weekpicker = function(options) {
 
+        // Default options
+        var defaults = {
+            label: "Week %W, %Y",
+        };
+        
+        //Settings for instance
+        var settings = $.extend( {}, defaults, options );
+        
         // Variables
         var currentDate = moment(),
             selectedWeek,
@@ -35,8 +43,8 @@
                 year += 1;
             }
             selectedYear = year;
-
-            element.val("Week " + calendarWeek + ", " + year);
+            
+            element.val(settings.label.replace('%W',calendarWeek).replace('%Y',year));
         }
 
         function createButton (direction, siblingElement) {


### PR DESCRIPTION
Unfortunately, there is no possibility to modify the input format.
moment.js unfortunately does not modify this input, so I added to the settings class where it is possible to change the input format.

for example, for the Czech Republic I will use the format `$("#weekpicker1").weekpicker({label: '%W.week, %Y'})`

I kept `Week %W, %Y` by default.